### PR TITLE
Use `mimalloc` as the default allocator for some targets

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,32 +16,38 @@ jobs:
           - {
               runner: ubuntu-latest,
               target: x86_64,
-              interpreter: "3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11"
+              interpreter: "3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11",
+              maturin-args: "--features mimalloc",
             }
           - {
               runner: ubuntu-latest,
               target: x86,
-              interpreter: "3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11"
+              interpreter: "3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11",
+              maturin-args: "--features mimalloc",
             }
           - {
               runner: ubuntu-latest,
               target: aarch64,
-              interpreter: "3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11"
+              interpreter: "3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11",
+              maturin-args: "--features mimalloc --zig",
             }
           - {
               runner: ubuntu-latest,
               target: armv7,
-              interpreter: "3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11"
+              interpreter: "3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11",
+              maturin-args: "",
             }
           - {
               runner: ubuntu-latest,
               target: s390x,
-              interpreter: "3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11"
+              interpreter: "3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11",
+              maturin-args: "",
             }
           - {
               runner: ubuntu-latest,
               target: ppc64le,
-              interpreter: "3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11"
+              interpreter: "3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11",
+              maturin-args: "",
             }
     steps:
       - uses: actions/checkout@v5
@@ -56,7 +62,9 @@ jobs:
         uses: PyO3/maturin-action@v1.49.4
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter ${{ matrix.platform.interpreter }}
+          args: >
+            --release --out dist ${{ matrix.platform.maturin-args }} 
+            --interpreter ${{ matrix.platform.interpreter }}
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: auto
           rust-toolchain: nightly
@@ -104,7 +112,10 @@ jobs:
         uses: PyO3/maturin-action@v1.49.4
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter ${{ matrix.platform.interpreter }}
+          args: > 
+            --release --out dist 
+            --interpreter ${{ matrix.platform.interpreter }} 
+            --features mimalloc
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: musllinux_1_2
           rust-toolchain: nightly
@@ -142,7 +153,10 @@ jobs:
         uses: PyO3/maturin-action@v1.49.4
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter ${{ matrix.platform.interpreter }}
+          args: >
+            --release --out dist
+            --interpreter ${{ matrix.platform.interpreter }} 
+            --features mimalloc
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           rust-toolchain: nightly
 
@@ -180,7 +194,10 @@ jobs:
         uses: PyO3/maturin-action@v1.49.4
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter ${{ matrix.platform.interpreter }}
+          args: >
+            --release --out dist 
+            --interpreter ${{ matrix.platform.interpreter }} 
+            --features mimalloc
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           rust-toolchain: nightly
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ features = ["inline-more", "raw"]
 version = "2.3.0"
 
 [dependencies.pyo3]
-version = "0.27.0"
+version = "0.27.1"
 default-features = false
 features = ["macros", "extension-module", "generate-import-lib"]
 
@@ -40,8 +40,13 @@ version = "1.0.3"
 [dependencies.parking_lot]
 version = "0.12.5"
 
+[dependencies.mimalloc]
+version = "0.1.48"
+features = ["v3", "override"]
+optional = true
+
 [build-dependencies.pyo3-build-config]
-version = "0.27.0"
+version = "0.27.1"
 features = ["resolve-config"]
 
 [lints.clippy]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,10 @@ mod common;
 mod bridge;
 mod policies;
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// cachebox core ( written in Rust )
 #[pyo3::pymodule(gil_used = false)]
 mod _core {


### PR DESCRIPTION
main repo: https://github.com/microsoft/mimalloc 

rust crate: https://github.com/purpleprotocol/mimalloc_rust

For some targets, this provides approximately a 10-15% speed increase. 