### PR TITLE
fix: correct typing for `cached` function

### DIFF
--- a/python/cachebox/utils.py
+++ b/python/cachebox/utils.py
@@ -463,7 +463,7 @@ def _async_cached_wrapper(
 
 
 def cached(
-    cache: typing.Union[BaseCacheImpl, dict, None],
+    cache: typing.Union[BaseCacheImpl, dict, typing.Callable[..., BaseCacheImpl], None],
     key_maker: typing.Callable[[tuple, dict], typing.Hashable] = make_key,
     clear_reuse: bool = False,
     callback: typing.Optional[typing.Callable[[int, typing.Any, typing.Any], typing.Any]] = None,


### PR DESCRIPTION
This PR fixes typing issue `cachebox.cached` applied on an instance method:

```python
import cachebox


class A:
    _cache: cachebox.BaseCacheImpl

    def __init__(self) -> None:
        self._cache = cachebox.Cache(128)

    # before PR: Argument of type "(self: Unknown) -> Unknown" cannot be assigned to parameter "cache" of type "BaseCacheImpl[Unknown, Unknown] | dict[Unknown, Unknown] | None" in function "cached"
    # after PR: no error
    @cachebox.cached(lambda self: self._cache)
    def method(self, *args, **kwargs) -> None: ...
```