### PR TITLE
docs: Fix broken documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ assert cache.get("key") == "value"
 ```
 
 ## Learn more
-Read the documentation for full information and learn more: [**Documentation**](https://awolverp.github.com/cachebox)
+Read the documentation for full information and learn more: [**Documentation**](https://awolverp.github.io/cachebox/)
 
 ## License
 This repository is licensed under the [MIT License](LICENSE)


### PR DESCRIPTION
Fixes #59.

The doc link at the end was broken.