### PR TITLE
Call the setdefault_with factory without holding the lock

### DIFF
--- a/cachebox/_core.pyi
+++ b/cachebox/_core.pyi
@@ -384,7 +384,7 @@ class Cache(BaseCacheImpl[KT, VT]):
         """
         Get `key`s value, or automatically create and insert one via `factory`.
         If `key` exists, its current value is returned and `factory` is not called.
-        Otherwise `factory` is called exactly once under an internal lock, its
+        Otherwise `factory` is called with the internal lock released, its
         result is inserted and returned.
 
         Args:
@@ -392,8 +392,9 @@ class Cache(BaseCacheImpl[KT, VT]):
             factory: The factory to call and get default value from if ``key`` is not in the cache.
 
         Warning:
-            `factory` must not call back into this cache (deadlock risk) or block
-            for long. If `factory` raises, nothing is inserted and the exception
+            if two threads miss the same key at once, `factory` can run
+            more than once; the value inserted first wins and is returned to
+            both. If `factory` raises, nothing is inserted and the exception
             propagates.
         """
         ...
@@ -565,7 +566,7 @@ class FIFOCache(BaseCacheImpl[KT, VT]):
         """
         Get `key`s value, or automatically create and insert one via `factory`.
         If `key` exists, its current value is returned and `factory` is not called.
-        Otherwise `factory` is called exactly once under an internal lock, its
+        Otherwise `factory` is called with the internal lock released, its
         result is inserted and returned.
 
         Args:
@@ -573,8 +574,9 @@ class FIFOCache(BaseCacheImpl[KT, VT]):
             factory: The factory to call and get default value from if ``key`` is not in the cache.
 
         Warning:
-            `factory` must not call back into this cache (deadlock risk) or block
-            for long. If `factory` raises, nothing is inserted and the exception
+            if two threads miss the same key at once, `factory` can run
+            more than once; the value inserted first wins and is returned to
+            both. If `factory` raises, nothing is inserted and the exception
             propagates.
         """
         ...
@@ -779,7 +781,7 @@ class RRCache(BaseCacheImpl[KT, VT]):
         """
         Get `key`s value, or automatically create and insert one via `factory`.
         If `key` exists, its current value is returned and `factory` is not called.
-        Otherwise `factory` is called exactly once under an internal lock, its
+        Otherwise `factory` is called with the internal lock released, its
         result is inserted and returned.
 
         Args:
@@ -787,8 +789,9 @@ class RRCache(BaseCacheImpl[KT, VT]):
             factory: The factory to call and get default value from if ``key`` is not in the cache.
 
         Warning:
-            `factory` must not call back into this cache (deadlock risk) or block
-            for long. If `factory` raises, nothing is inserted and the exception
+            if two threads miss the same key at once, `factory` can run
+            more than once; the value inserted first wins and is returned to
+            both. If `factory` raises, nothing is inserted and the exception
             propagates.
         """
         ...
@@ -986,7 +989,7 @@ class LRUCache(BaseCacheImpl[KT, VT]):
         """
         Get `key`s value, or automatically create and insert one via `factory`.
         If `key` exists, its current value is returned and `factory` is not called.
-        Otherwise `factory` is called exactly once under an internal lock, its
+        Otherwise `factory` is called with the internal lock released, its
         result is inserted and returned.
 
         Args:
@@ -994,8 +997,9 @@ class LRUCache(BaseCacheImpl[KT, VT]):
             factory: The factory to call and get default value from if ``key`` is not in the cache.
 
         Warning:
-            `factory` must not call back into this cache (deadlock risk) or block
-            for long. If `factory` raises, nothing is inserted and the exception
+            if two threads miss the same key at once, `factory` can run
+            more than once; the value inserted first wins and is returned to
+            both. If `factory` raises, nothing is inserted and the exception
             propagates.
         """
         ...
@@ -1234,7 +1238,7 @@ class LFUCache(BaseCacheImpl[KT, VT]):
         """
         Get `key`s value, or automatically create and insert one via `factory`.
         If `key` exists, its current value is returned and `factory` is not called.
-        Otherwise `factory` is called exactly once under an internal lock, its
+        Otherwise `factory` is called with the internal lock released, its
         result is inserted and returned.
 
         Args:
@@ -1242,8 +1246,9 @@ class LFUCache(BaseCacheImpl[KT, VT]):
             factory: The factory to call and get default value from if ``key`` is not in the cache.
 
         Warning:
-            `factory` must not call back into this cache (deadlock risk) or block
-            for long. If `factory` raises, nothing is inserted and the exception
+            if two threads miss the same key at once, `factory` can run
+            more than once; the value inserted first wins and is returned to
+            both. If `factory` raises, nothing is inserted and the exception
             propagates.
         """
         ...
@@ -1441,7 +1446,7 @@ class TTLCache(BaseCacheImpl[KT, VT]):
         """
         Get `key`s value, or automatically create and insert one via `factory`.
         If `key` exists, its current value is returned and `factory` is not called.
-        Otherwise `factory` is called exactly once under an internal lock, its
+        Otherwise `factory` is called with the internal lock released, its
         result is inserted and returned.
 
         Args:
@@ -1449,8 +1454,9 @@ class TTLCache(BaseCacheImpl[KT, VT]):
             factory: The factory to call and get default value from if ``key`` is not in the cache.
 
         Warning:
-            `factory` must not call back into this cache (deadlock risk) or block
-            for long. If `factory` raises, nothing is inserted and the exception
+            if two threads miss the same key at once, `factory` can run
+            more than once; the value inserted first wins and is returned to
+            both. If `factory` raises, nothing is inserted and the exception
             propagates.
         """
         ...
@@ -1708,7 +1714,7 @@ class VTTLCache(BaseCacheImpl[KT, VT]):
         """
         Get `key`s value, or automatically create and insert one via `factory`.
         If `key` exists, its current value is returned and `factory` is not called.
-        Otherwise `factory` is called exactly once under an internal lock, its
+        Otherwise `factory` is called with the internal lock released, its
         result is inserted and returned.
 
         Args:
@@ -1717,8 +1723,9 @@ class VTTLCache(BaseCacheImpl[KT, VT]):
             ttl: An optional time-to-live duration for item.
 
         Warning:
-            `factory` must not call back into this cache (deadlock risk) or block
-            for long. If `factory` raises, nothing is inserted and the exception
+            if two threads miss the same key at once, `factory` can run
+            more than once; the value inserted first wins and is returned to
+            both. If `factory` raises, nothing is inserted and the exception
             propagates.
         """
         ...

--- a/src/pyclasses/cache.rs
+++ b/src/pyclasses/cache.rs
@@ -359,11 +359,12 @@ impl PyCache {
     /// Get `key`s value, or automatically create and insert one via `factory`.
     ///
     /// If `key` exists, its current value is returned and `factory` is not called.
-    /// Otherwise `factory` is called exactly once under an internal lock, its
+    /// Otherwise `factory` is called with the internal lock released, its
     /// result is inserted and returned.
     ///
-    /// Warning: `factory` must not call back into this cache (deadlock risk) or block
-    /// for long. If `factory` raises, nothing is inserted and the exception
+    /// Warning: if two threads miss the same key at once, `factory` can run
+    /// more than once; the value inserted first wins and is returned to
+    /// both. If `factory` raises, nothing is inserted and the exception
     /// propagates.
     fn setdefault_with(
         &self,
@@ -378,13 +379,23 @@ impl PyCache {
 
         let inner = self.0.get();
         let shared = inner.shared();
+
+        {
+            let mut policy = inner.policy();
+
+            if let Some(x) = policy.get(py, &key)? {
+                return Ok(x.value().clone_ref(py));
+            }
+        }
+
+        // `factory` is Python code: a GC pass inside it would deadlock on `__traverse__`
+        let default_object = factory.call0(py)?;
+
         let mut policy = inner.policy();
 
         if let Some(x) = policy.get(py, &key)? {
             return Ok(x.value().clone_ref(py));
         }
-
-        let default_object = factory.call0(py)?;
 
         let handle = nopolicy::Handle::with_precomputed_hash_key(
             py,

--- a/src/pyclasses/fifocache.rs
+++ b/src/pyclasses/fifocache.rs
@@ -365,11 +365,12 @@ impl PyFIFOCache {
     /// Get `key`s value, or automatically create and insert one via `factory`.
     ///
     /// If `key` exists, its current value is returned and `factory` is not called.
-    /// Otherwise `factory` is called exactly once under an internal lock, its
+    /// Otherwise `factory` is called with the internal lock released, its
     /// result is inserted and returned.
     ///
-    /// Warning: `factory` must not call back into this cache (deadlock risk) or block
-    /// for long. If `factory` raises, nothing is inserted and the exception
+    /// Warning: if two threads miss the same key at once, `factory` can run
+    /// more than once; the value inserted first wins and is returned to
+    /// both. If `factory` raises, nothing is inserted and the exception
     /// propagates.
     fn setdefault_with(
         &self,
@@ -384,13 +385,23 @@ impl PyFIFOCache {
 
         let inner = self.0.get();
         let shared = inner.shared();
+
+        {
+            let mut policy = inner.policy();
+
+            if let Some(x) = policy.get(py, &key)? {
+                return Ok(x.value().clone_ref(py));
+            }
+        }
+
+        // `factory` is Python code: a GC pass inside it would deadlock on `__traverse__`
+        let default_object = factory.call0(py)?;
+
         let mut policy = inner.policy();
 
         if let Some(x) = policy.get(py, &key)? {
             return Ok(x.value().clone_ref(py));
         }
-
-        let default_object = factory.call0(py)?;
 
         let handle = fifopolicy::Handle::with_precomputed_hash_key(
             py,

--- a/src/pyclasses/lfucache.rs
+++ b/src/pyclasses/lfucache.rs
@@ -384,11 +384,12 @@ impl PyLFUCache {
     /// Get `key`s value, or automatically create and insert one via `factory`.
     ///
     /// If `key` exists, its current value is returned and `factory` is not called.
-    /// Otherwise, `factory` is called exactly once under an internal lock, its
+    /// Otherwise, `factory` is called with the internal lock released, its
     /// result is inserted and returned.
     ///
-    /// Warning: `factory` must not call back into this cache (deadlock risk) or block
-    /// for long. If `factory` raises, nothing is inserted and the exception
+    /// Warning: if two threads miss the same key at once, `factory` can run
+    /// more than once; the value inserted first wins and is returned to
+    /// both. If `factory` raises, nothing is inserted and the exception
     /// propagates.
     fn setdefault_with(
         &self,
@@ -403,13 +404,23 @@ impl PyLFUCache {
 
         let inner = self.0.get();
         let shared = inner.shared();
+
+        {
+            let mut policy = inner.policy();
+
+            if let Some(x) = policy.get(py, &key)? {
+                return Ok(x.value().clone_ref(py));
+            }
+        }
+
+        // `factory` is Python code: a GC pass inside it would deadlock on `__traverse__`
+        let default_object = factory.call0(py)?;
+
         let mut policy = inner.policy();
 
         if let Some(x) = policy.get(py, &key)? {
             return Ok(x.value().clone_ref(py));
         }
-
-        let default_object = factory.call0(py)?;
 
         let handle = lfupolicy::FrequencyHandle::with_precomputed_hash_key(
             py,

--- a/src/pyclasses/lrucache.rs
+++ b/src/pyclasses/lrucache.rs
@@ -392,11 +392,12 @@ impl PyLRUCache {
     /// Get `key`s value, or automatically create and insert one via `factory`.
     ///
     /// If `key` exists, its current value is returned and `factory` is not called.
-    /// Otherwise `factory` is called exactly once under an internal lock, its
+    /// Otherwise `factory` is called with the internal lock released, its
     /// result is inserted and returned.
     ///
-    /// Warning: `factory` must not call back into this cache (deadlock risk) or block
-    /// for long. If `factory` raises, nothing is inserted and the exception
+    /// Warning: if two threads miss the same key at once, `factory` can run
+    /// more than once; the value inserted first wins and is returned to
+    /// both. If `factory` raises, nothing is inserted and the exception
     /// propagates.
     fn setdefault_with(
         &self,
@@ -411,13 +412,23 @@ impl PyLRUCache {
 
         let inner = self.0.get();
         let shared = inner.shared();
+
+        {
+            let mut policy = inner.policy();
+
+            if let Some(x) = policy.get(py, &key)? {
+                return Ok(x.value().clone_ref(py));
+            }
+        }
+
+        // `factory` is Python code: a GC pass inside it would deadlock on `__traverse__`
+        let default_object = factory.call0(py)?;
+
         let mut policy = inner.policy();
 
         if let Some(x) = policy.get(py, &key)? {
             return Ok(x.value().clone_ref(py));
         }
-
-        let default_object = factory.call0(py)?;
 
         let handle = lrupolicy::Handle::with_precomputed_hash_key(
             py,

--- a/src/pyclasses/rrcache.rs
+++ b/src/pyclasses/rrcache.rs
@@ -363,11 +363,12 @@ impl PyRRCache {
     /// Get `key`s value, or automatically create and insert one via `factory`.
     ///
     /// If `key` exists, its current value is returned and `factory` is not called.
-    /// Otherwise `factory` is called exactly once under an internal lock, its
+    /// Otherwise `factory` is called with the internal lock released, its
     /// result is inserted and returned.
     ///
-    /// Warning: `factory` must not call back into this cache (deadlock risk) or block
-    /// for long. If `factory` raises, nothing is inserted and the exception
+    /// Warning: if two threads miss the same key at once, `factory` can run
+    /// more than once; the value inserted first wins and is returned to
+    /// both. If `factory` raises, nothing is inserted and the exception
     /// propagates.
     fn setdefault_with(
         &self,
@@ -382,13 +383,23 @@ impl PyRRCache {
 
         let inner = self.0.get();
         let shared = inner.shared();
+
+        {
+            let mut policy = inner.policy();
+
+            if let Some(x) = policy.get(py, &key)? {
+                return Ok(x.value().clone_ref(py));
+            }
+        }
+
+        // `factory` is Python code: a GC pass inside it would deadlock on `__traverse__`
+        let default_object = factory.call0(py)?;
+
         let mut policy = inner.policy();
 
         if let Some(x) = policy.get(py, &key)? {
             return Ok(x.value().clone_ref(py));
         }
-
-        let default_object = factory.call0(py)?;
 
         let handle = rrpolicy::Handle::with_precomputed_hash_key(
             py,

--- a/src/pyclasses/ttlcache.rs
+++ b/src/pyclasses/ttlcache.rs
@@ -369,11 +369,12 @@ impl PyTTLCache {
     /// Get `key`s value, or automatically create and insert one via `factory`.
     ///
     /// If `key` exists, its current value is returned and `factory` is not called.
-    /// Otherwise, `factory` is called exactly once under an internal lock, its
+    /// Otherwise, `factory` is called with the internal lock released, its
     /// result is inserted and returned.
     ///
-    /// Warning: `factory` must not call back into this cache (deadlock risk) or block
-    /// for long. If `factory` raises, nothing is inserted and the exception
+    /// Warning: if two threads miss the same key at once, `factory` can run
+    /// more than once; the value inserted first wins and is returned to
+    /// both. If `factory` raises, nothing is inserted and the exception
     /// propagates.
     fn setdefault_with(
         &self,
@@ -388,13 +389,23 @@ impl PyTTLCache {
 
         let inner = self.0.get();
         let shared = inner.shared();
+
+        {
+            let mut policy = inner.policy();
+
+            if let Some(x) = policy.get(py, &key)? {
+                return Ok(x.value().clone_ref(py));
+            }
+        }
+
+        // `factory` is Python code: a GC pass inside it would deadlock on `__traverse__`
+        let default_object = factory.call0(py)?;
+
         let mut policy = inner.policy();
 
         if let Some(x) = policy.get(py, &key)? {
             return Ok(x.value().clone_ref(py));
         }
-
-        let default_object = factory.call0(py)?;
 
         let handle = ttlpolicy::ExpiringHandle::with_precomputed_hash_key(
             py,

--- a/src/pyclasses/vttlcache.rs
+++ b/src/pyclasses/vttlcache.rs
@@ -366,13 +366,23 @@ impl PyVTTLCache {
 
         let inner = self.0.get();
         let shared = inner.shared();
+
+        {
+            let mut policy = inner.policy();
+
+            if let Some(x) = policy.get(py, &key)? {
+                return Ok(x.value().clone_ref(py));
+            }
+        }
+
+        // `factory` is Python code: a GC pass inside it would deadlock on `__traverse__`
+        let default_object = factory.call0(py)?;
+
         let mut policy = inner.policy();
 
         if let Some(x) = policy.get(py, &key)? {
             return Ok(x.value().clone_ref(py));
         }
-
-        let default_object = factory.call0(py)?;
 
         let handle = vttlpolicy::ExpiringHandle::with_precomputed_hash_key(
             py,

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -2,6 +2,7 @@ import copy as stdcopy
 import dataclasses
 import gc
 import pickle
+import subprocess
 import sys
 import threading
 import time
@@ -202,6 +203,28 @@ class SetDefaultMixin(BaseMixin):
         assert cache.get("k") == "existing"
 
 
+FACTORY_TOUCHING_CACHE = """
+import gc
+import sys
+
+import cachebox
+
+name = sys.argv[1]
+cls = getattr(cachebox, name)
+cache = cls(10, global_ttl=60) if name == "TTLCache" else cls(10)
+cache.insert("seen", "value")
+
+
+def factory():
+    gc.collect()
+    return cache["seen"]
+
+
+assert cache.setdefault_with("k", factory) == "value"
+print("ok")
+"""
+
+
 class SetDefaultWithMixin(BaseMixin):
     def test_setdefault_with_inserts_when_absent(self):
         cache = self.create_cache()
@@ -239,6 +262,22 @@ class SetDefaultWithMixin(BaseMixin):
 
         with pytest.raises(ValueError):
             cache.setdefault_with("k", factory)
+
+    def test_setdefault_with_factory_may_touch_the_cache_and_the_gc(self):
+        # a deadlock here would keep the GIL, so the call runs in a child process
+        name = type(self.create_cache()).__name__
+
+        try:
+            done = subprocess.run(
+                [sys.executable, "-c", FACTORY_TOUCHING_CACHE, name],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        except subprocess.TimeoutExpired:
+            pytest.fail(f"{name}.setdefault_with never returned")
+
+        assert done.stdout.strip() == "ok", done.stderr
 
 
 class PopAndDeleteMixin(BaseMixin):


### PR DESCRIPTION
Closes #67

The factory used to run while the internal lock was held, and `__traverse__` takes that same lock, so a GC pass inside the factory froze the process. Now the key is looked up under the lock, the lock is dropped, the factory runs without it, and then the lock is taken again to re-check the key before inserting. Same change in all seven cache types, plus the doc strings.

One behaviour change: if two threads miss the same key at the same time, the factory can run twice. The value inserted first stays in the cache and is returned to both of them, so no caller ends up holding an object the cache does not have.

The test sits in the shared mixin, so it runs for all seven types. It does the call in a child process on purpose: a deadlock keeps the GIL, so a watchdog inside the same process would never fire. Without the patch the test fails with "never returned" instead of freezing the whole run.

`1004 passed, 6 skipped`. The suite also stopped hanging: 4 freezes in 9 runs before, 5 clean runs out of 5 after.