### PR TITLE
Make iterators hold a reference to the cache

### DIFF
--- a/src/pyclasses/cache.rs
+++ b/src/pyclasses/cache.rs
@@ -531,52 +531,55 @@ impl PyCache {
             .map(|x| !x)
     }
 
-    fn items(&self) -> pyo3::PyResult<pyo3::Py<PyCacheItems>> {
-        let inner = self.0.get();
+    fn items(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyCacheItems>> {
+        let inner = slf.get().0.get();
         let gv = inner.shared().generation_version().clone();
         let initial_gv = gv.get();
 
         let result = PyCacheItems {
+            cache: slf.as_any().clone().unbind(),
             // SAFETY: We cannot use lifetimes here, but we're tracking changes using [`GenerationVersion`]
             iter: parking_lot::Mutex::new(unsafe { inner.policy().table().iter() }),
             gv,
             initial_gv,
         };
 
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
-    fn values(&self) -> pyo3::PyResult<pyo3::Py<PyCacheValues>> {
-        let inner = self.0.get();
+    fn values(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyCacheValues>> {
+        let inner = slf.get().0.get();
         let gv = inner.shared().generation_version().clone();
         let initial_gv = gv.get();
 
         let result = PyCacheValues {
+            cache: slf.as_any().clone().unbind(),
             // SAFETY: We cannot use lifetimes here, but we're tracking changes using [`GenerationVersion`]
             iter: parking_lot::Mutex::new(unsafe { inner.policy().table().iter() }),
             gv,
             initial_gv,
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
-    fn keys(&self) -> pyo3::PyResult<pyo3::Py<PyCacheKeys>> {
-        let inner = self.0.get();
+    fn keys(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyCacheKeys>> {
+        let inner = slf.get().0.get();
         let gv = inner.shared().generation_version().clone();
         let initial_gv = gv.get();
 
         let result = PyCacheKeys {
+            cache: slf.as_any().clone().unbind(),
             // SAFETY: We cannot use lifetimes here, but we're tracking changes using [`GenerationVersion`]
             iter: parking_lot::Mutex::new(unsafe { inner.policy().table().iter() }),
             gv,
             initial_gv,
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
     #[inline]
-    fn __iter__(&self) -> pyo3::PyResult<pyo3::Py<PyCacheKeys>> {
-        self.keys()
+    fn __iter__(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyCacheKeys>> {
+        Self::keys(slf)
     }
 
     fn copy(&self, py: pyo3::Python) -> pyo3::PyResult<pyo3::Py<Self>> {
@@ -670,6 +673,7 @@ macro_rules! implement_iterator {
         $(
             implement_pyclass! {
                 [generic, frozen] $name as $pyname {
+                    cache: pyo3::Py<pyo3::PyAny>,
                     initial_gv: u32,
                     gv: utils::GenerationVersion,
                     iter: parking_lot::Mutex<crate::hashbrown::raw::RawIter<nopolicy::Handle>>,
@@ -681,6 +685,10 @@ macro_rules! implement_iterator {
                 #[inline]
                 fn __iter__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyRef<'_, Self> {
                     slf
+                }
+
+                fn __traverse__(&self, visit: pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
+                    visit.call(&self.cache)
                 }
 
                 fn __next__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<$rt_type> {

--- a/src/pyclasses/fifocache.rs
+++ b/src/pyclasses/fifocache.rs
@@ -535,51 +535,54 @@ impl PyFIFOCache {
             .map(|x| !x)
     }
 
-    fn items(&self) -> pyo3::PyResult<pyo3::Py<PyFIFOCacheItems>> {
-        let inner = self.0.get();
+    fn items(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyFIFOCacheItems>> {
+        let inner = slf.get().0.get();
         let gv = inner.shared().generation_version().clone();
         let initial_gv = gv.get();
 
         // SAFETY: We cannot use lifetimes here, but we're tracking changes using [`GenerationVersion`]
         let result = PyFIFOCacheItems {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(inner.policy().iter()),
             gv,
             initial_gv,
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
-    fn values(&self) -> pyo3::PyResult<pyo3::Py<PyFIFOCacheValues>> {
-        let inner = self.0.get();
+    fn values(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyFIFOCacheValues>> {
+        let inner = slf.get().0.get();
         let gv = inner.shared().generation_version().clone();
         let initial_gv = gv.get();
 
         // SAFETY: We cannot use lifetimes here, but we're tracking changes using [`GenerationVersion`]
         let result = PyFIFOCacheValues {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(inner.policy().iter()),
             gv,
             initial_gv,
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
-    fn keys(&self) -> pyo3::PyResult<pyo3::Py<PyFIFOCacheKeys>> {
-        let inner = self.0.get();
+    fn keys(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyFIFOCacheKeys>> {
+        let inner = slf.get().0.get();
         let gv = inner.shared().generation_version().clone();
         let initial_gv = gv.get();
 
         // SAFETY: We cannot use lifetimes here, but we're tracking changes using [`GenerationVersion`]
         let result = PyFIFOCacheKeys {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(inner.policy().iter()),
             gv,
             initial_gv,
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
     #[inline]
-    fn __iter__(&self) -> pyo3::PyResult<pyo3::Py<PyFIFOCacheKeys>> {
-        self.keys()
+    fn __iter__(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyFIFOCacheKeys>> {
+        Self::keys(slf)
     }
 
     fn copy(&self, py: pyo3::Python) -> pyo3::PyResult<pyo3::Py<Self>> {
@@ -696,6 +699,7 @@ macro_rules! implement_iterator {
         $(
             implement_pyclass! {
                 [generic, frozen] $name as $pyname {
+                    cache: pyo3::Py<pyo3::PyAny>,
                     initial_gv: u32,
                     gv: utils::GenerationVersion,
                     iter: parking_lot::Mutex<utils::RawVecDequeIter<fifopolicy::Handle>>,
@@ -707,6 +711,10 @@ macro_rules! implement_iterator {
                 #[inline]
                 fn __iter__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyRef<'_, Self> {
                     slf
+                }
+
+                fn __traverse__(&self, visit: pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
+                    visit.call(&self.cache)
                 }
 
                 fn __next__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<$rt_type> {

--- a/src/pyclasses/lfucache.rs
+++ b/src/pyclasses/lfucache.rs
@@ -554,69 +554,75 @@ impl PyLFUCache {
             .map(|x| !x)
     }
 
-    fn items(&self) -> pyo3::PyResult<pyo3::Py<PyLFUCacheItems>> {
-        let inner = self.0.get();
+    fn items(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyLFUCacheItems>> {
+        let inner = slf.get().0.get();
         let mut policy = inner.policy();
 
         let gv = inner.shared().generation_version();
         let iter = policy.iter(gv);
 
         let result = PyLFUCacheItems {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(iter),
             gv: gv.clone(),
             initial_gv: gv.get(),
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
-    fn values(&self) -> pyo3::PyResult<pyo3::Py<PyLFUCacheValues>> {
-        let inner = self.0.get();
+    fn values(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyLFUCacheValues>> {
+        let inner = slf.get().0.get();
         let mut policy = inner.policy();
 
         let gv = inner.shared().generation_version();
         let iter = policy.iter(gv);
 
         let result = PyLFUCacheValues {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(iter),
             gv: gv.clone(),
             initial_gv: gv.get(),
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
-    fn keys(&self) -> pyo3::PyResult<pyo3::Py<PyLFUCacheKeys>> {
-        let inner = self.0.get();
+    fn keys(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyLFUCacheKeys>> {
+        let inner = slf.get().0.get();
         let mut policy = inner.policy();
 
         let gv = inner.shared().generation_version();
         let iter = policy.iter(gv);
 
         let result = PyLFUCacheKeys {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(iter),
             gv: gv.clone(),
             initial_gv: gv.get(),
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
     #[inline]
-    fn __iter__(&self) -> pyo3::PyResult<pyo3::Py<PyLFUCacheKeys>> {
-        self.keys()
+    fn __iter__(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyLFUCacheKeys>> {
+        Self::keys(slf)
     }
 
-    fn items_with_frequency(&self) -> pyo3::PyResult<pyo3::Py<PyLFUCacheItemsWithFrequency>> {
-        let inner = self.0.get();
+    fn items_with_frequency(
+        slf: pyo3::Bound<'_, Self>,
+    ) -> pyo3::PyResult<pyo3::Py<PyLFUCacheItemsWithFrequency>> {
+        let inner = slf.get().0.get();
         let mut policy = inner.policy();
 
         let gv = inner.shared().generation_version();
         let iter = policy.iter(gv);
 
         let result = PyLFUCacheItemsWithFrequency {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(iter),
             gv: gv.clone(),
             initial_gv: gv.get(),
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
     fn copy(&self, py: pyo3::Python) -> pyo3::PyResult<pyo3::Py<Self>> {
@@ -760,6 +766,7 @@ macro_rules! implement_iterator {
         $(
             implement_pyclass! {
                 [generic, frozen] $name as $pyname {
+                    cache: pyo3::Py<pyo3::PyAny>,
                     initial_gv: u32,
                     gv: utils::GenerationVersion,
                     iter: parking_lot::Mutex<lazyheap::RawIter<lfupolicy::FrequencyHandle>>,
@@ -771,6 +778,10 @@ macro_rules! implement_iterator {
                 #[inline]
                 fn __iter__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyRef<'_, Self> {
                     slf
+                }
+
+                fn __traverse__(&self, visit: pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
+                    visit.call(&self.cache)
                 }
 
                 fn __next__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<$rt_type> {

--- a/src/pyclasses/lrucache.rs
+++ b/src/pyclasses/lrucache.rs
@@ -562,51 +562,54 @@ impl PyLRUCache {
             .map(|x| !x)
     }
 
-    fn items(&self) -> pyo3::PyResult<pyo3::Py<PyLRUCacheItems>> {
-        let inner = self.0.get();
+    fn items(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyLRUCacheItems>> {
+        let inner = slf.get().0.get();
         let gv = inner.shared().generation_version().clone();
         let initial_gv = gv.get();
 
         // SAFETY: We cannot use lifetimes here, but we're tracking changes using [`GenerationVersion`]
         let result = PyLRUCacheItems {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(unsafe { inner.policy().list().iter() }),
             gv,
             initial_gv,
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
-    fn values(&self) -> pyo3::PyResult<pyo3::Py<PyLRUCacheValues>> {
-        let inner = self.0.get();
+    fn values(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyLRUCacheValues>> {
+        let inner = slf.get().0.get();
         let gv = inner.shared().generation_version().clone();
         let initial_gv = gv.get();
 
         // SAFETY: We cannot use lifetimes here, but we're tracking changes using [`GenerationVersion`]
         let result = PyLRUCacheValues {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(unsafe { inner.policy().list().iter() }),
             gv,
             initial_gv,
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
-    fn keys(&self) -> pyo3::PyResult<pyo3::Py<PyLRUCacheKeys>> {
-        let inner = self.0.get();
+    fn keys(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyLRUCacheKeys>> {
+        let inner = slf.get().0.get();
         let gv = inner.shared().generation_version().clone();
         let initial_gv = gv.get();
 
         // SAFETY: We cannot use lifetimes here, but we're tracking changes using [`GenerationVersion`]
         let result = PyLRUCacheKeys {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(unsafe { inner.policy().list().iter() }),
             gv,
             initial_gv,
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
     #[inline]
-    fn __iter__(&self) -> pyo3::PyResult<pyo3::Py<PyLRUCacheKeys>> {
-        self.keys()
+    fn __iter__(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyLRUCacheKeys>> {
+        Self::keys(slf)
     }
 
     fn copy(&self, py: pyo3::Python) -> pyo3::PyResult<pyo3::Py<Self>> {
@@ -744,6 +747,7 @@ macro_rules! implement_iterator {
         $(
             implement_pyclass! {
                 [generic, frozen] $name as $pyname {
+                    cache: pyo3::Py<pyo3::PyAny>,
                     initial_gv: u32,
                     gv: utils::GenerationVersion,
                     iter: parking_lot::Mutex<linked_list::RawIter<lrupolicy::Handle>>,
@@ -755,6 +759,10 @@ macro_rules! implement_iterator {
                 #[inline]
                 fn __iter__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyRef<'_, Self> {
                     slf
+                }
+
+                fn __traverse__(&self, visit: pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
+                    visit.call(&self.cache)
                 }
 
                 fn __next__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<$rt_type> {

--- a/src/pyclasses/rrcache.rs
+++ b/src/pyclasses/rrcache.rs
@@ -535,51 +535,54 @@ impl PyRRCache {
             .map(|x| !x)
     }
 
-    fn items(&self) -> pyo3::PyResult<pyo3::Py<PyRRCacheItems>> {
-        let inner = self.0.get();
+    fn items(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyRRCacheItems>> {
+        let inner = slf.get().0.get();
         let gv = inner.shared().generation_version().clone();
         let initial_gv = gv.get();
 
         // SAFETY: We cannot use lifetimes here, but we're tracking changes using [`GenerationVersion`]
         let result = PyRRCacheItems {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(unsafe { inner.policy().table().iter() }),
             gv,
             initial_gv,
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
-    fn values(&self) -> pyo3::PyResult<pyo3::Py<PyRRCacheValues>> {
-        let inner = self.0.get();
+    fn values(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyRRCacheValues>> {
+        let inner = slf.get().0.get();
         let gv = inner.shared().generation_version().clone();
         let initial_gv = gv.get();
 
         // SAFETY: We cannot use lifetimes here, but we're tracking changes using [`GenerationVersion`]
         let result = PyRRCacheValues {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(unsafe { inner.policy().table().iter() }),
             gv,
             initial_gv,
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
-    fn keys(&self) -> pyo3::PyResult<pyo3::Py<PyRRCacheKeys>> {
-        let inner = self.0.get();
+    fn keys(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyRRCacheKeys>> {
+        let inner = slf.get().0.get();
         let gv = inner.shared().generation_version().clone();
         let initial_gv = gv.get();
 
         // SAFETY: We cannot use lifetimes here, but we're tracking changes using [`GenerationVersion`]
         let result = PyRRCacheKeys {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(unsafe { inner.policy().table().iter() }),
             gv,
             initial_gv,
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
     #[inline]
-    fn __iter__(&self) -> pyo3::PyResult<pyo3::Py<PyRRCacheKeys>> {
-        self.keys()
+    fn __iter__(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyRRCacheKeys>> {
+        Self::keys(slf)
     }
 
     fn copy(&self, py: pyo3::Python) -> pyo3::PyResult<pyo3::Py<Self>> {
@@ -690,6 +693,7 @@ macro_rules! implement_iterator {
         $(
             implement_pyclass! {
                 [generic, frozen] $name as $pyname {
+                    cache: pyo3::Py<pyo3::PyAny>,
                     initial_gv: u32,
                     gv: utils::GenerationVersion,
                     iter: parking_lot::Mutex<crate::hashbrown::raw::RawIter<rrpolicy::Handle>>,
@@ -701,6 +705,10 @@ macro_rules! implement_iterator {
                 #[inline]
                 fn __iter__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyRef<'_, Self> {
                     slf
+                }
+
+                fn __traverse__(&self, visit: pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
+                    visit.call(&self.cache)
                 }
 
                 fn __next__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<$rt_type> {

--- a/src/pyclasses/ttlcache.rs
+++ b/src/pyclasses/ttlcache.rs
@@ -540,8 +540,8 @@ impl PyTTLCache {
             .map(|x| !x)
     }
 
-    fn items(&self) -> pyo3::PyResult<pyo3::Py<PyTTLCacheItems>> {
-        let inner = self.0.get();
+    fn items(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyTTLCacheItems>> {
+        let inner = slf.get().0.get();
 
         let iter = inner.policy().iter(inner.shared());
 
@@ -550,15 +550,16 @@ impl PyTTLCache {
 
         // SAFETY: We cannot use lifetimes here, but we're tracking changes using [`GenerationVersion`]
         let result = PyTTLCacheItems {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(iter),
             gv,
             initial_gv,
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
-    fn values(&self) -> pyo3::PyResult<pyo3::Py<PyTTLCacheValues>> {
-        let inner = self.0.get();
+    fn values(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyTTLCacheValues>> {
+        let inner = slf.get().0.get();
 
         let iter = inner.policy().iter(inner.shared());
 
@@ -567,15 +568,16 @@ impl PyTTLCache {
 
         // SAFETY: We cannot use lifetimes here, but we're tracking changes using [`GenerationVersion`]
         let result = PyTTLCacheValues {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(iter),
             gv,
             initial_gv,
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
-    fn keys(&self) -> pyo3::PyResult<pyo3::Py<PyTTLCacheKeys>> {
-        let inner = self.0.get();
+    fn keys(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyTTLCacheKeys>> {
+        let inner = slf.get().0.get();
 
         let iter = inner.policy().iter(inner.shared());
 
@@ -584,16 +586,17 @@ impl PyTTLCache {
 
         // SAFETY: We cannot use lifetimes here, but we're tracking changes using [`GenerationVersion`]
         let result = PyTTLCacheKeys {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(iter),
             gv,
             initial_gv,
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
     #[inline]
-    fn __iter__(&self) -> pyo3::PyResult<pyo3::Py<PyTTLCacheKeys>> {
-        self.keys()
+    fn __iter__(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyTTLCacheKeys>> {
+        Self::keys(slf)
     }
 
     fn copy(&self, py: pyo3::Python) -> pyo3::PyResult<pyo3::Py<Self>> {
@@ -776,8 +779,10 @@ impl PyTTLCache {
         Ok((key.into(), val, dur.as_secs_f64()))
     }
 
-    fn items_with_expire(&self) -> pyo3::PyResult<pyo3::Py<PyTTLCacheItemsWithExpire>> {
-        let inner = self.0.get();
+    fn items_with_expire(
+        slf: pyo3::Bound<'_, Self>,
+    ) -> pyo3::PyResult<pyo3::Py<PyTTLCacheItemsWithExpire>> {
+        let inner = slf.get().0.get();
 
         let iter = inner.policy().iter(inner.shared());
 
@@ -786,11 +791,12 @@ impl PyTTLCache {
 
         // SAFETY: We cannot use lifetimes here, but we're tracking changes using [`GenerationVersion`]
         let result = PyTTLCacheItemsWithExpire {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(iter),
             gv,
             initial_gv,
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
     fn __traverse__(&self, visit: pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
@@ -830,6 +836,7 @@ macro_rules! implement_iterator {
         $(
             implement_pyclass! {
                 [generic, frozen] $name as $pyname {
+                    cache: pyo3::Py<pyo3::PyAny>,
                     initial_gv: u32,
                     gv: utils::GenerationVersion,
                     iter: parking_lot::Mutex<utils::RawVecDequeIter<ttlpolicy::ExpiringHandle>>,
@@ -841,6 +848,10 @@ macro_rules! implement_iterator {
                 #[inline]
                 fn __iter__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyRef<'_, Self> {
                     slf
+                }
+
+                fn __traverse__(&self, visit: pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
+                    visit.call(&self.cache)
                 }
 
                 fn __next__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<$rt_type> {

--- a/src/pyclasses/vttlcache.rs
+++ b/src/pyclasses/vttlcache.rs
@@ -515,54 +515,57 @@ impl PyVTTLCache {
             .map(|x| !x)
     }
 
-    fn items(&self) -> pyo3::PyResult<pyo3::Py<PyVTTLCacheItems>> {
-        let inner = self.0.get();
+    fn items(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyVTTLCacheItems>> {
+        let inner = slf.get().0.get();
         let mut policy = inner.policy();
 
         let gv = inner.shared().generation_version();
         let iter = policy.iter(gv);
 
         let result = PyVTTLCacheItems {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(iter),
             gv: gv.clone(),
             initial_gv: gv.get(),
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
-    fn values(&self) -> pyo3::PyResult<pyo3::Py<PyVTTLCacheValues>> {
-        let inner = self.0.get();
+    fn values(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyVTTLCacheValues>> {
+        let inner = slf.get().0.get();
         let mut policy = inner.policy();
 
         let gv = inner.shared().generation_version();
         let iter = policy.iter(gv);
 
         let result = PyVTTLCacheValues {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(iter),
             gv: gv.clone(),
             initial_gv: gv.get(),
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
-    fn keys(&self) -> pyo3::PyResult<pyo3::Py<PyVTTLCacheKeys>> {
-        let inner = self.0.get();
+    fn keys(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyVTTLCacheKeys>> {
+        let inner = slf.get().0.get();
         let mut policy = inner.policy();
 
         let gv = inner.shared().generation_version();
         let iter = policy.iter(gv);
 
         let result = PyVTTLCacheKeys {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(iter),
             gv: gv.clone(),
             initial_gv: gv.get(),
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
     #[inline]
-    fn __iter__(&self) -> pyo3::PyResult<pyo3::Py<PyVTTLCacheKeys>> {
-        self.keys()
+    fn __iter__(slf: pyo3::Bound<'_, Self>) -> pyo3::PyResult<pyo3::Py<PyVTTLCacheKeys>> {
+        Self::keys(slf)
     }
 
     fn copy(&self, py: pyo3::Python) -> pyo3::PyResult<pyo3::Py<Self>> {
@@ -739,19 +742,22 @@ impl PyVTTLCache {
         Ok((key.into(), val, dur))
     }
 
-    fn items_with_expire(&self) -> pyo3::PyResult<pyo3::Py<PyVTTLCacheItemsWithExpire>> {
-        let inner = self.0.get();
+    fn items_with_expire(
+        slf: pyo3::Bound<'_, Self>,
+    ) -> pyo3::PyResult<pyo3::Py<PyVTTLCacheItemsWithExpire>> {
+        let inner = slf.get().0.get();
         let mut policy = inner.policy();
 
         let gv = inner.shared().generation_version();
         let iter = policy.iter(gv);
 
         let result = PyVTTLCacheItemsWithExpire {
+            cache: slf.as_any().clone().unbind(),
             iter: parking_lot::Mutex::new(iter),
             gv: gv.clone(),
             initial_gv: gv.get(),
         };
-        pyo3::Python::attach(|py| pyo3::Py::new(py, result))
+        pyo3::Py::new(slf.py(), result)
     }
 
     fn __traverse__(&self, visit: pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
@@ -793,6 +799,7 @@ macro_rules! implement_iterator {
         $(
             implement_pyclass! {
                 [generic, frozen] $name as $pyname {
+                    cache: pyo3::Py<pyo3::PyAny>,
                     initial_gv: u32,
                     gv: utils::GenerationVersion,
                     iter: parking_lot::Mutex<lazyheap::RawIter<vttlpolicy::ExpiringHandle>>,
@@ -804,6 +811,10 @@ macro_rules! implement_iterator {
                 #[inline]
                 fn __iter__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyRef<'_, Self> {
                     slf
+                }
+
+                fn __traverse__(&self, visit: pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
+                    visit.call(&self.cache)
                 }
 
                 fn __next__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<$rt_type> {

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -2,6 +2,7 @@ import copy as stdcopy
 import dataclasses
 import gc
 import pickle
+import platform
 import subprocess
 import sys
 import threading
@@ -464,6 +465,11 @@ class IterationMixin(BaseMixin):
 
         assert done.stdout.strip() == "ok", done.stderr or f"exit code {done.returncode}"
 
+    @pytest.mark.skipif(
+        platform.python_implementation() == "PyPy",
+        reason="PyPy's GC does not collect cycles through the cache objects: "
+        "a cache holding itself is not collected either",
+    )
     def test_cache_holding_its_own_iterator_is_collected(self):
         class Canary:
             pass

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -2,10 +2,12 @@ import copy as stdcopy
 import dataclasses
 import gc
 import pickle
+import subprocess
 import sys
 import threading
 import time
 import typing
+import weakref
 from datetime import timedelta
 from unittest.mock import Mock, patch
 
@@ -401,6 +403,29 @@ class IntrospectionMixin(BaseMixin):
         assert c1 != c2
 
 
+WALKING_A_TEMPORARY_CACHE = """
+import sys
+
+import cachebox
+
+name = sys.argv[1]
+cls = getattr(cachebox, name)
+
+
+def make():
+    cache = cls(10, global_ttl=60) if name == "TTLCache" else cls(10)
+    cache.update({"a": 1, "b": 2})
+    return cache
+
+
+# nothing else holds the cache by the time the walk starts
+assert set(make().keys()) == {"a", "b"}
+assert set(make().items()) == {("a", 1), ("b", 2)}
+assert sorted(make().values()) == [1, 2]
+print("ok")
+"""
+
+
 class IterationMixin(BaseMixin):
     def test_keys_returns_all_keys(self):
         cache = self.create_cache()
@@ -425,6 +450,34 @@ class IterationMixin(BaseMixin):
 
         cache.update({"x": 10, "y": 20})
         assert set(iter(cache)) == {"x", "y"}
+
+    def test_walking_a_cache_nothing_else_holds(self):
+        # reading freed memory faults instead of failing, so it runs in a child process
+        name = type(self.create_cache()).__name__
+
+        done = subprocess.run(
+            [sys.executable, "-c", WALKING_A_TEMPORARY_CACHE, name],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+        assert done.stdout.strip() == "ok", done.stderr or f"exit code {done.returncode}"
+
+    def test_cache_holding_its_own_iterator_is_collected(self):
+        class Canary:
+            pass
+
+        canary = Canary()
+        ref = weakref.ref(canary)
+
+        cache = self.create_cache()
+        cache.insert("canary", canary)
+        cache.insert("self", cache.keys())  # the cycle: cache -> iterator -> cache
+        del cache, canary
+        gc.collect()
+
+        assert ref() is None
 
     def test_generation_version_on_remove(self):
         cache = self.create_cache(10, {i: i for i in range(10)})


### PR DESCRIPTION
Closes #69

The iterator types kept a raw cursor and a generation counter, but no reference to the cache object, so a cache that nothing else held was freed while the walk was still running, and the walk read freed memory. Now every iterator type holds a `Py<PyAny>` to the cache: `keys`, `values` and `items` take `slf` instead of `&self` and store it. `__traverse__` is there so the cycle "cache holds the iterator as a value, iterator holds the cache" stays collectable; `__clear__` is not needed, the cache's own `__clear__` breaks that cycle.

No answers change, and speed does not change either: creating an iterator stays at 37 ns.

Two tests in the shared mixin, so they run for all seven types: walking a cache that nothing else holds, and a cache that holds its own iterator still being collected. The walk runs in a child process on purpose: reading freed memory takes the whole run down instead of failing a test. Without the patch it fails for `Cache` and `LRUCache` and passes for the other five, which is what reading freed memory looks like.

`1011 passed, 6 skipped`, 5 runs out of 5. Those runs have #68 applied on top: on plain main the suite freezes in almost every run because of #67, which this branch does not touch.