### PR TITLE
Add __len__ and __bool__ to cache iterators

### DIFF
--- a/cachebox/_core.pyi
+++ b/cachebox/_core.pyi
@@ -9,6 +9,7 @@ __version__: typing.Final[str]
 KT = typing.TypeVar("KT", bound=typing.Hashable)
 VT = typing.TypeVar("VT")
 DT = typing.TypeVar("DT")
+T_co = typing.TypeVar("T_co", covariant=True)
 
 _IterableType: typing.TypeAlias = (
     typing.Dict[KT, VT]
@@ -16,6 +17,43 @@ _IterableType: typing.TypeAlias = (
     | BaseCacheImpl[KT, VT]
     | typing.Iterable[typing.Tuple[KT, VT]]
 )
+
+class CacheIterator(typing.Generic[T_co]):
+    """
+    What ``keys()``, ``values()`` and ``items()`` return.
+
+    This is a one-shot iterator, not a ``dict`` view: it walks the cache once
+    and is empty after that. It knows how many items it still has to yield, so
+    ``len()`` and ``bool()`` work on it, but it does not support ``in`` or set
+    operations the way ``dict.keys()`` does.
+
+    Warning:
+        Do not modify the cache while one of these is alive. Every method
+        raises ``RuntimeError`` if the cache changed.
+    """
+
+    def __iter__(self) -> typing.Self: ...
+    def __next__(self) -> T_co: ...
+    def __len__(self) -> int:
+        """
+        Returns how many items are left to yield.
+
+        For ``TTLCache`` and ``VTTLCache`` this skips expired entries, which
+        takes O(n).
+
+        Returns:
+            The number of items left.
+        """
+        ...
+
+    def __bool__(self) -> bool:
+        """
+        Returns whether any item is left to yield.
+
+        Returns:
+            ``True`` if at least one item is left.
+        """
+        ...
 
 class BaseCacheImpl(typing.Generic[KT, VT]):
     """
@@ -221,10 +259,10 @@ class BaseCacheImpl(typing.Generic[KT, VT]):
 
     def __eq__(self, other: typing.Any) -> bool: ...
     def __ne__(self, other: typing.Any) -> bool: ...
-    def items(self) -> typing.Iterable[typing.Tuple[KT, VT]]: ...
-    def values(self) -> typing.Iterable[VT]: ...
-    def keys(self) -> typing.Iterable[KT]: ...
-    def __iter__(self) -> typing.Iterator[KT]: ...
+    def items(self) -> CacheIterator[typing.Tuple[KT, VT]]: ...
+    def values(self) -> CacheIterator[VT]: ...
+    def keys(self) -> CacheIterator[KT]: ...
+    def __iter__(self) -> CacheIterator[KT]: ...
     def copy(self) -> typing.Self: ...
     def __copy__(self) -> typing.Self: ...
     def __getstate__(self) -> object: ...
@@ -410,7 +448,7 @@ class Cache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def items(self) -> typing.Iterable[typing.Tuple[KT, VT]]:
+    def items(self) -> CacheIterator[typing.Tuple[KT, VT]]:
         """
         Returns an iterable of the cache's ``(key, value)`` pairs.
 
@@ -422,7 +460,7 @@ class Cache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def keys(self) -> typing.Iterable[KT]:
+    def keys(self) -> CacheIterator[KT]:
         """
         Returns an iterable of the cache's keys.
 
@@ -434,7 +472,7 @@ class Cache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def values(self) -> typing.Iterable[VT]:
+    def values(self) -> CacheIterator[VT]:
         """
         Returns an iterable of the cache's values.
 
@@ -593,7 +631,7 @@ class FIFOCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def items(self) -> typing.Iterable[typing.Tuple[KT, VT]]:
+    def items(self) -> CacheIterator[typing.Tuple[KT, VT]]:
         """
         Returns an ordered iterable of the cache's ``(key, value)`` pairs.
 
@@ -605,7 +643,7 @@ class FIFOCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def keys(self) -> typing.Iterable[KT]:
+    def keys(self) -> CacheIterator[KT]:
         """
         Returns an ordered iterable of the cache's keys.
 
@@ -617,7 +655,7 @@ class FIFOCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def values(self) -> typing.Iterable[VT]:
+    def values(self) -> CacheIterator[VT]:
         """
         Returns an ordered iterable of the cache's values.
 
@@ -808,7 +846,7 @@ class RRCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def items(self) -> typing.Iterable[typing.Tuple[KT, VT]]:
+    def items(self) -> CacheIterator[typing.Tuple[KT, VT]]:
         """
         Returns an iterable of the cache's ``(key, value)`` pairs.
 
@@ -820,7 +858,7 @@ class RRCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def keys(self) -> typing.Iterable[KT]:
+    def keys(self) -> CacheIterator[KT]:
         """
         Returns an iterable of the cache's keys.
 
@@ -832,7 +870,7 @@ class RRCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def values(self) -> typing.Iterable[VT]:
+    def values(self) -> CacheIterator[VT]:
         """
         Returns an iterable of the cache's values.
 
@@ -1016,7 +1054,7 @@ class LRUCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def items(self) -> typing.Iterable[typing.Tuple[KT, VT]]:
+    def items(self) -> CacheIterator[typing.Tuple[KT, VT]]:
         """
         Returns an ordered iterable of the cache's ``(key, value)`` pairs.
 
@@ -1028,7 +1066,7 @@ class LRUCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def keys(self) -> typing.Iterable[KT]:
+    def keys(self) -> CacheIterator[KT]:
         """
         Returns an ordered iterable of the cache's keys.
 
@@ -1040,7 +1078,7 @@ class LRUCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def values(self) -> typing.Iterable[VT]:
+    def values(self) -> CacheIterator[VT]:
         """
         Returns an ordered iterable of the cache's values.
 
@@ -1265,7 +1303,7 @@ class LFUCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def items(self) -> typing.Iterable[typing.Tuple[KT, VT]]:
+    def items(self) -> CacheIterator[typing.Tuple[KT, VT]]:
         """
         Returns an ordered iterable of the cache's ``(key, value)`` pairs.
 
@@ -1277,7 +1315,7 @@ class LFUCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def keys(self) -> typing.Iterable[KT]:
+    def keys(self) -> CacheIterator[KT]:
         """
         Returns an ordered iterable of the cache's keys.
 
@@ -1289,7 +1327,7 @@ class LFUCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def values(self) -> typing.Iterable[VT]:
+    def values(self) -> CacheIterator[VT]:
         """
         Returns an ordered iterable of the cache's values.
 
@@ -1301,7 +1339,7 @@ class LFUCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def items_with_frequency(self) -> typing.Iterable[typing.Tuple[KT, VT, int]]:
+    def items_with_frequency(self) -> CacheIterator[typing.Tuple[KT, VT, int]]:
         """
         Returns an ordered iterable of the cache's ``(key, value)`` pairs with their
         frequency counter.
@@ -1473,7 +1511,7 @@ class TTLCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def items(self) -> typing.Iterable[typing.Tuple[KT, VT]]:
+    def items(self) -> CacheIterator[typing.Tuple[KT, VT]]:
         """
         Returns an ordered iterable of the cache's ``(key, value)`` pairs.
 
@@ -1485,7 +1523,7 @@ class TTLCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def keys(self) -> typing.Iterable[KT]:
+    def keys(self) -> CacheIterator[KT]:
         """
         Returns an ordered iterable of the cache's keys.
 
@@ -1497,7 +1535,7 @@ class TTLCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def values(self) -> typing.Iterable[VT]:
+    def values(self) -> CacheIterator[VT]:
         """
         Returns an ordered iterable of the cache's values.
 
@@ -1599,7 +1637,7 @@ class TTLCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def items_with_expire(self) -> typing.Iterable[typing.Tuple[KT, VT, float]]:
+    def items_with_expire(self) -> CacheIterator[typing.Tuple[KT, VT, float]]:
         """
         Returns an ordered iterable of items with their remaining TTL.
 
@@ -1741,7 +1779,7 @@ class VTTLCache(BaseCacheImpl[KT, VT]):
             KeyError: If the cache is empty.
         """
 
-    def items(self) -> typing.Iterable[typing.Tuple[KT, VT]]:
+    def items(self) -> CacheIterator[typing.Tuple[KT, VT]]:
         """
         Returns an ordered iterable of the cache's ``(key, value)`` pairs.
 
@@ -1753,7 +1791,7 @@ class VTTLCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def keys(self) -> typing.Iterable[KT]:
+    def keys(self) -> CacheIterator[KT]:
         """
         Returns an ordered iterable of the cache's keys.
 
@@ -1765,7 +1803,7 @@ class VTTLCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def values(self) -> typing.Iterable[VT]:
+    def values(self) -> CacheIterator[VT]:
         """
         Returns an ordered iterable of the cache's values.
 
@@ -1838,7 +1876,7 @@ class VTTLCache(BaseCacheImpl[KT, VT]):
         """
         ...
 
-    def items_with_expire(self) -> typing.Iterable[typing.Tuple[KT, VT, float | None]]:
+    def items_with_expire(self) -> CacheIterator[typing.Tuple[KT, VT, float | None]]:
         """
         Returns an ordered iterable of items with their remaining TTL.
 

--- a/cachebox/_core.pyi
+++ b/cachebox/_core.pyi
@@ -18,7 +18,7 @@ _IterableType: typing.TypeAlias = (
     | typing.Iterable[typing.Tuple[KT, VT]]
 )
 
-class CacheIterator(typing.Generic[T_co]):
+class CacheIterator(typing.Iterator[T_co]):
     """
     What ``keys()``, ``values()`` and ``items()`` return.
 

--- a/cachebox/_core.pyi
+++ b/cachebox/_core.pyi
@@ -32,7 +32,6 @@ class CacheIterator(typing.Iterator[T_co]):
         raises ``RuntimeError`` if the cache changed.
     """
 
-    def __iter__(self) -> typing.Self: ...
     def __next__(self) -> T_co: ...
     def __len__(self) -> int:
         """

--- a/src/internal/lazyheap.rs
+++ b/src/internal/lazyheap.rs
@@ -340,6 +340,24 @@ impl<T> Iterator for RawIter<T> {
             }
         }
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let left = self.first.len() + self.second.len();
+        (left, Some(left))
+    }
+}
+
+impl<T> ExactSizeIterator for RawIter<T> {}
+
+impl<T> Clone for RawIter<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            first: self.first.clone(),
+            second: self.second.clone(),
+        }
+    }
 }
 
 unsafe impl<T: Send + Send> Send for LazyHeap<T> {}

--- a/src/internal/linked_list.rs
+++ b/src/internal/linked_list.rs
@@ -640,6 +640,8 @@ impl<T> Iterator for RawIter<T> {
     }
 }
 
+impl<T> ExactSizeIterator for RawIter<T> {}
+
 unsafe impl<T: Send + Send> Send for LinkedList<T> {}
 unsafe impl<T: Sync + Sync> Sync for LinkedList<T> {}
 unsafe impl<T: Send + Send> Send for RawIter<T> {}

--- a/src/internal/utils.rs
+++ b/src/internal/utils.rs
@@ -476,6 +476,26 @@ impl<T> Iterator for RawSliceIter<T> {
             Some(value)
         }
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let left = self.len - self.index;
+        (left, Some(left))
+    }
+}
+
+impl<T> ExactSizeIterator for RawSliceIter<T> {}
+
+// Cloning gives a second cursor over the same elements; it never touches them.
+impl<T> Clone for RawSliceIter<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            pointer: self.pointer,
+            index: self.index,
+            len: self.len,
+        }
+    }
 }
 
 unsafe impl<T: Sync> Send for RawSliceIter<T> {}
@@ -512,6 +532,24 @@ impl<T> Iterator for RawVecDequeIter<T> {
                 std::mem::swap(&mut self.first, &mut self.second);
                 self.first.next()
             }
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let left = self.first.len() + self.second.len();
+        (left, Some(left))
+    }
+}
+
+impl<T> ExactSizeIterator for RawVecDequeIter<T> {}
+
+impl<T> Clone for RawVecDequeIter<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            first: self.first.clone(),
+            second: self.second.clone(),
         }
     }
 }

--- a/src/macro_rules.rs
+++ b/src/macro_rules.rs
@@ -25,6 +25,33 @@ macro_rules! implement_pyclass {
     };
 }
 
+/// Implements the generation-version guard shared by every cache view type.
+///
+/// # Example
+///
+/// ```ignore
+/// implement_view_guard!(PyCacheKeys);
+/// ```
+#[macro_export]
+macro_rules! implement_view_guard {
+    ($name:ident) => {
+        impl $name {
+            /// Fails if the cache changed after this view was created.
+            #[inline]
+            fn check_generation(&self) -> pyo3::PyResult<()> {
+                if self.initial_gv == self.gv.get() {
+                    return Ok(());
+                }
+
+                Err($crate::new_py_error!(
+                    PyRuntimeError,
+                    "cache size changed during iteration"
+                ))
+            }
+        }
+    };
+}
+
 /// Creates a new [`PyErr`] of the given exception type.
 #[macro_export]
 macro_rules! new_py_error {

--- a/src/pyclasses/cache.rs
+++ b/src/pyclasses/cache.rs
@@ -691,6 +691,8 @@ macro_rules! implement_iterator {
                 }
             }
 
+            implement_view_guard!($name);
+
             #[pyo3::pymethods]
             impl $name {
                 #[inline]
@@ -703,12 +705,7 @@ macro_rules! implement_iterator {
                 }
 
                 fn __next__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<$rt_type> {
-                    if slf.initial_gv != slf.gv.get() {
-                        return Err(new_py_error!(
-                            PyRuntimeError,
-                            "cache size changed during iteration"
-                        ));
-                    }
+                    slf.check_generation()?;
 
                     let mut iter = slf.iter.lock();
 
@@ -720,6 +717,13 @@ macro_rules! implement_iterator {
                         }
                         None => return Err(new_py_error!(PyStopIteration, ())),
                     }
+                }
+
+                /// Returns how many items are left to yield.
+                fn __len__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<usize> {
+                    slf.check_generation()?;
+
+                    Ok(slf.iter.lock().len())
                 }
             }
         )+

--- a/src/pyclasses/fifocache.rs
+++ b/src/pyclasses/fifocache.rs
@@ -717,6 +717,8 @@ macro_rules! implement_iterator {
                 }
             }
 
+            implement_view_guard!($name);
+
             #[pyo3::pymethods]
             impl $name {
                 #[inline]
@@ -729,12 +731,7 @@ macro_rules! implement_iterator {
                 }
 
                 fn __next__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<$rt_type> {
-                    if slf.initial_gv != slf.gv.get() {
-                        return Err(new_py_error!(
-                            PyRuntimeError,
-                            "cache size changed during iteration"
-                        ));
-                    }
+                    slf.check_generation()?;
 
                     let mut iter = slf.iter.lock();
 
@@ -746,6 +743,13 @@ macro_rules! implement_iterator {
                         }
                         None => return Err(new_py_error!(PyStopIteration, ())),
                     }
+                }
+
+                /// Returns how many items are left to yield.
+                fn __len__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<usize> {
+                    slf.check_generation()?;
+
+                    Ok(slf.iter.lock().len())
                 }
             }
         )+

--- a/src/pyclasses/lfucache.rs
+++ b/src/pyclasses/lfucache.rs
@@ -784,6 +784,8 @@ macro_rules! implement_iterator {
                 }
             }
 
+            implement_view_guard!($name);
+
             #[pyo3::pymethods]
             impl $name {
                 #[inline]
@@ -796,12 +798,7 @@ macro_rules! implement_iterator {
                 }
 
                 fn __next__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<$rt_type> {
-                    if slf.initial_gv != slf.gv.get() {
-                        return Err(new_py_error!(
-                            PyRuntimeError,
-                            "cache size changed during iteration"
-                        ));
-                    }
+                    slf.check_generation()?;
 
                     let mut iter = slf.iter.lock();
 
@@ -813,6 +810,13 @@ macro_rules! implement_iterator {
                         }
                         None => return Err(new_py_error!(PyStopIteration, ())),
                     }
+                }
+
+                /// Returns how many items are left to yield.
+                fn __len__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<usize> {
+                    slf.check_generation()?;
+
+                    Ok(slf.iter.lock().len())
                 }
             }
         )+

--- a/src/pyclasses/lrucache.rs
+++ b/src/pyclasses/lrucache.rs
@@ -765,6 +765,8 @@ macro_rules! implement_iterator {
                 }
             }
 
+            implement_view_guard!($name);
+
             #[pyo3::pymethods]
             impl $name {
                 #[inline]
@@ -777,12 +779,7 @@ macro_rules! implement_iterator {
                 }
 
                 fn __next__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<$rt_type> {
-                    if slf.initial_gv != slf.gv.get() {
-                        return Err(new_py_error!(
-                            PyRuntimeError,
-                            "cache size changed during iteration"
-                        ));
-                    }
+                    slf.check_generation()?;
 
                     let mut iter = slf.iter.lock();
 
@@ -794,6 +791,13 @@ macro_rules! implement_iterator {
                         }
                         None => return Err(new_py_error!(PyStopIteration, ())),
                     }
+                }
+
+                /// Returns how many items are left to yield.
+                fn __len__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<usize> {
+                    slf.check_generation()?;
+
+                    Ok(slf.iter.lock().len())
                 }
             }
         )+

--- a/src/pyclasses/rrcache.rs
+++ b/src/pyclasses/rrcache.rs
@@ -711,6 +711,8 @@ macro_rules! implement_iterator {
                 }
             }
 
+            implement_view_guard!($name);
+
             #[pyo3::pymethods]
             impl $name {
                 #[inline]
@@ -723,12 +725,7 @@ macro_rules! implement_iterator {
                 }
 
                 fn __next__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<$rt_type> {
-                    if slf.initial_gv != slf.gv.get() {
-                        return Err(new_py_error!(
-                            PyRuntimeError,
-                            "cache size changed during iteration"
-                        ));
-                    }
+                    slf.check_generation()?;
 
                     let mut iter = slf.iter.lock();
 
@@ -740,6 +737,13 @@ macro_rules! implement_iterator {
                         }
                         None => return Err(new_py_error!(PyStopIteration, ())),
                     }
+                }
+
+                /// Returns how many items are left to yield.
+                fn __len__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<usize> {
+                    slf.check_generation()?;
+
+                    Ok(slf.iter.lock().len())
                 }
             }
         )+

--- a/src/pyclasses/ttlcache.rs
+++ b/src/pyclasses/ttlcache.rs
@@ -854,6 +854,8 @@ macro_rules! implement_iterator {
                 }
             }
 
+            implement_view_guard!($name);
+
             #[pyo3::pymethods]
             impl $name {
                 #[inline]
@@ -866,12 +868,7 @@ macro_rules! implement_iterator {
                 }
 
                 fn __next__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<$rt_type> {
-                    if slf.initial_gv != slf.gv.get() {
-                        return Err(new_py_error!(
-                            PyRuntimeError,
-                            "cache size changed during iteration"
-                        ));
-                    }
+                    slf.check_generation()?;
 
                     let now = std::time::SystemTime::now();
                     let mut iter = slf.iter.lock();
@@ -887,6 +884,26 @@ macro_rules! implement_iterator {
                     }
 
                     Err(new_py_error!(PyStopIteration, ()))
+                }
+
+                /// Returns how many not-expired items are left to yield.
+                fn __len__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<usize> {
+                    slf.check_generation()?;
+
+                    let now = std::time::SystemTime::now();
+                    let iter = slf.iter.lock().clone();
+
+                    Ok(iter.filter(|x| !unsafe { x.as_ref() }.is_expired(now)).count())
+                }
+
+                /// Returns whether any not-expired item is left, without counting them all.
+                fn __bool__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<bool> {
+                    slf.check_generation()?;
+
+                    let now = std::time::SystemTime::now();
+                    let mut iter = slf.iter.lock().clone();
+
+                    Ok(iter.any(|x| !unsafe { x.as_ref() }.is_expired(now)))
                 }
             }
         )+

--- a/src/pyclasses/vttlcache.rs
+++ b/src/pyclasses/vttlcache.rs
@@ -816,6 +816,8 @@ macro_rules! implement_iterator {
                 }
             }
 
+            implement_view_guard!($name);
+
             #[pyo3::pymethods]
             impl $name {
                 #[inline]
@@ -828,12 +830,7 @@ macro_rules! implement_iterator {
                 }
 
                 fn __next__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<$rt_type> {
-                    if slf.initial_gv != slf.gv.get() {
-                        return Err(new_py_error!(
-                            PyRuntimeError,
-                            "cache size changed during iteration"
-                        ));
-                    }
+                    slf.check_generation()?;
 
                     let now = std::time::SystemTime::now();
                     let mut iter = slf.iter.lock();
@@ -849,6 +846,26 @@ macro_rules! implement_iterator {
                     }
 
                     Err(new_py_error!(PyStopIteration, ()))
+                }
+
+                /// Returns how many not-expired items are left to yield.
+                fn __len__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<usize> {
+                    slf.check_generation()?;
+
+                    let now = std::time::SystemTime::now();
+                    let iter = slf.iter.lock().clone();
+
+                    Ok(iter.filter(|x| !unsafe { x.element() }.is_expired(now)).count())
+                }
+
+                /// Returns whether any not-expired item is left, without counting them all.
+                fn __bool__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyResult<bool> {
+                    slf.check_generation()?;
+
+                    let now = std::time::SystemTime::now();
+                    let mut iter = slf.iter.lock().clone();
+
+                    Ok(iter.any(|x| !unsafe { x.element() }.is_expired(now)))
                 }
             }
         )+

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -523,6 +523,46 @@ class IterationMixin(BaseMixin):
 
         assert ref() is None
 
+    def test_iterators_report_len(self):
+        cache = self.create_cache()
+
+        cache.update({"a": 1, "b": 2, "c": 3})
+        assert len(cache.keys()) == 3
+        assert len(cache.values()) == 3
+        assert len(cache.items()) == 3
+
+    def test_iterator_len_counts_what_is_left(self):
+        cache = self.create_cache()
+
+        cache.update({"a": 1, "b": 2, "c": 3})
+        it = cache.keys()
+
+        next(it)
+        assert len(it) == 2
+
+        list(it)
+        assert len(it) == 0
+
+    def test_empty_iterator_is_falsy(self):
+        cache = self.create_cache()
+
+        assert not cache.keys()
+        assert not cache.values()
+        assert not cache.items()
+
+        cache.insert("a", 1)
+        assert cache.keys()
+
+    def test_iterator_len_after_cache_changed(self):
+        cache = self.create_cache()
+
+        cache.insert("a", 1)
+        it = cache.keys()
+        cache.insert("b", 2)
+
+        with pytest.raises(RuntimeError):
+            len(it)
+
     def test_generation_version_on_remove(self):
         cache = self.create_cache(10, {i: i for i in range(10)})
 

--- a/tests/test_impls.py
+++ b/tests/test_impls.py
@@ -1021,6 +1021,21 @@ class TestTTLCachePolicy(mixins.SweepIntervalMixin):
         with pytest.raises(ValueError):
             c = self.create_cache(10, global_ttl=-1)
 
+    def test_iterator_len_skips_expired_item_behind_a_live_one(self):
+        cache = self.create_cache(global_ttl=1)
+
+        cache.insert("A", 1)
+        cache.insert("B", 2)
+        time.sleep(0.6)
+        cache.insert("A", 11)  # refreshed, but keeps its place in front of "B"
+        time.sleep(0.6)
+
+        # "B" is expired, but the sweep stops at the live "A" in front of it
+        assert len(cache) == 2
+
+        assert len(cache.keys()) == 1
+        assert list(cache.keys()) == ["A"]
+
     def test_global_ttl_with_iterable(self):
         c = self.create_cache(10, {"A": "B", "C": "D"}, global_ttl=1)
         assert c.global_ttl == 1
@@ -1507,6 +1522,20 @@ class TestVTTLCachePolicy(mixins.SweepIntervalMixin):
         c.insert("k", "v", ttl=0.1)
         time.sleep(0.15)
         assert "k" not in c
+
+    def test_iterator_len_skips_item_expired_after_creation(self):
+        c = self.create_cache()
+        c.insert("alive", 1, ttl=10)
+        c.insert("soon", 2, ttl=0.2)
+
+        it = c.keys()
+        assert len(it) == 2
+
+        time.sleep(0.25)
+        assert len(it) == 1
+
+        # asking for the length does not consume the iterator
+        assert list(it) == ["alive"]
 
     def test_expired_item_not_returned_by_get(self):
         c = self.create_cache()

--- a/tests/test_impls.py
+++ b/tests/test_impls.py
@@ -128,6 +128,19 @@ class TestFIFOCachePolicy(mixins.BaseMixin):
             getsizeof=getsizeof,
         )
 
+    def test_iterator_len_correct_across_ring_wrap(self):
+        """Evictions wrap the ring buffer; len() must stay correct after every next()."""
+        cache = self.create_cache(5)
+        for i in range(9):
+            cache.insert(f"k{i}", i)
+
+        it = cache.keys()
+        for left in range(len(cache), 0, -1):
+            assert len(it) == left
+            next(it)
+
+        assert len(it) == 0
+
     def test_oldest_item_evicted_on_overflow(self):
         """When capacity is exceeded, the first inserted key must be evicted."""
         cache = self.create_cache(3, [(1, "a"), (2, "b"), (3, "c")])
@@ -1007,6 +1020,19 @@ class TestTTLCachePolicy(mixins.SweepIntervalMixin):
             getsizeof=getsizeof,
             sweep_interval=sweep_interval,
         )
+
+    def test_iterator_len_correct_across_ring_wrap(self):
+        """Evictions wrap the ring buffer; len() must stay correct after every next()."""
+        cache = self.create_cache(5)
+        for i in range(9):
+            cache.insert(f"k{i}", i)
+
+        it = cache.keys()
+        for left in range(len(cache), 0, -1):
+            assert len(it) == left
+            next(it)
+
+        assert len(it) == 0
 
     def test_global_ttl_property(self):
         c = self.create_cache(10, global_ttl=5)


### PR DESCRIPTION
Closes #73

The iterator types behind `keys()`, `values()` and `items()` get `__len__` and `__bool__`. `len()` says how many items the iterator will yield: for a fresh `cache.keys()` that is the number of live entries, the same number a `dict` view would report, and it goes down as a stored iterator is consumed, like any Python iterator. `operator.length_hint()` picks it up automatically, and `bool()` of an empty iterator becomes False instead of True, which is the point of the change.

On `Cache`, `FIFOCache`, `LRUCache`, `LFUCache` and `RRCache` the count is O(1). On `TTLCache` and `VTTLCache` it walks the entries and skips the expired ones, so it is O(n): the number has to match what the walk actually yields. There `len(cache.keys())` can be smaller than `len(cache)`, because an expired entry can sit behind a live one, and only the walk skips it. cachetools counts cheaper because its update moves the entry to the back, so everything expired sits at the head. In cachebox an update refreshes `expires_at` in place, so an exact count is either a walk on every `len()`, or a separate counter paid for on every insert. I picked the walk: `len()` is called rarely, inserts happen all the time.

If the cache changed after the iterator was created, `len()` and `bool()` raise the same RuntimeError that `__next__` already raises: the iterator's existing rule extended to the new methods, not a new restriction.

Six new tests: four in the shared mixin, so they run for all seven types, and two for the expired-entry cases on `TTLCache` and `VTTLCache`.