### PR TITLE
edit: modernize typing structure based on PEP 585 and 604

### DIFF
--- a/cachebox/utils.py
+++ b/cachebox/utils.py
@@ -3,6 +3,7 @@ import inspect
 import typing
 from copy import copy as _shallow_copy
 from copy import deepcopy as _deep_copy
+from collections.abc import Callable, Hashable
 
 from ._cachebox import BaseCacheImpl, LRUCache
 from ._wrappers import (
@@ -23,7 +24,7 @@ if typing.TYPE_CHECKING:
 KT = typing.TypeVar("KT")
 VT = typing.TypeVar("VT")
 DT = typing.TypeVar("DT")
-FT = typing.TypeVar("FT", bound=typing.Callable[..., typing.Any])
+FT = typing.TypeVar("FT", bound=Callable[..., typing.Any])
 
 
 _COPY_TYPES = frozenset((dict, list, set))
@@ -63,7 +64,7 @@ _KWDS_MARK = object()
 _FAST_TYPES = frozenset((int, str))
 
 
-def make_key(*args, **kwds) -> typing.Hashable:
+def make_key(*args: typing.Any, **kwds: typing.Any) -> Hashable:
     """
     Default cache key.
 
@@ -83,7 +84,7 @@ def make_key(*args, **kwds) -> typing.Hashable:
     return key
 
 
-def make_hash_key(*args, **kwds) -> int:
+def make_hash_key(*args: typing.Any, **kwds: typing.Any) -> int:
     """
     Key as the hash of all positional and keyword arguments.
 
@@ -98,7 +99,7 @@ def make_hash_key(*args, **kwds) -> int:
     return hash(key)
 
 
-def make_typed_key(*args, **kwds) -> tuple:
+def make_typed_key(*args: typing.Any, **kwds: typing.Any) -> tuple[typing.Any, ...]:
     """
     Key that includes the runtime type of every argument.
 
@@ -183,7 +184,7 @@ class Frozen(BaseCacheImpl[KT, VT]):  # pragma: no cover
         return self.__cache.maxsize
 
     @property
-    def getsizeof(self) -> typing.Callable[[KT, VT], int] | None:
+    def getsizeof(self) -> Callable[[KT, VT], int] | None:
         """Callable or None: The configured ``getsizeof`` function."""
         return self.__cache.getsizeof
 
@@ -271,7 +272,7 @@ class Frozen(BaseCacheImpl[KT, VT]):  # pragma: no cover
         value: VT,
         *args: typing.Any,
         **kwargs: typing.Any,
-    ) -> typing.Optional[VT]:
+    ) -> VT | None:
         return self._guard()
 
     def __setitem__(self, key: KT, value: VT) -> None:
@@ -285,7 +286,7 @@ class Frozen(BaseCacheImpl[KT, VT]):  # pragma: no cover
     ) -> None:
         return self._guard()
 
-    def get(self, key: KT, default: typing.Optional[DT] = None) -> typing.Union[VT, DT]:
+    def get(self, key: KT, default: DT | None = None) -> VT | DT:
         return self.__cache.get(key, default)
 
     def __getitem__(self, key: KT) -> VT:
@@ -294,13 +295,13 @@ class Frozen(BaseCacheImpl[KT, VT]):  # pragma: no cover
     def setdefault(
         self,
         key: KT,
-        default: typing.Optional[DT] = None,
+        default: DT | None = None,
         *args: typing.Any,
         **kwargs: typing.Any,
-    ) -> typing.Optional[VT | DT]:
+    ) -> VT | DT | None:
         return self._guard()
 
-    def pop(self, key: KT, default: DT = None) -> typing.Union[VT, DT]:
+    def pop(self, key: KT, default: DT | None = None) -> VT | DT:
         """
         Removes the specified key and returns the corresponding value.
 
@@ -319,7 +320,7 @@ class Frozen(BaseCacheImpl[KT, VT]):  # pragma: no cover
     def __delitem__(self, key: KT) -> None:
         return self._guard()
 
-    def popitem(self) -> typing.Tuple[KT, VT]:
+    def popitem(self) -> tuple[KT, VT]:
         return self._guard()  # type: ignore[return-value]
 
     def drain(self, n: int) -> int:
@@ -348,7 +349,7 @@ class Frozen(BaseCacheImpl[KT, VT]):  # pragma: no cover
         """
         return self._guard()
 
-    def items(self) -> typing.Iterable[typing.Tuple[KT, VT]]:
+    def items(self) -> typing.Iterable[tuple[KT, VT]]:
         return self.__cache.items()
 
     def values(self) -> typing.Iterable[VT]:
@@ -373,14 +374,14 @@ class Frozen(BaseCacheImpl[KT, VT]):  # pragma: no cover
 def _cast_lock(
     iscoroutinefunction: bool,
     lock: (
-        typing.Type[AbstractContextManager]
-        | typing.Type[AbstractAsyncContextManager]
+        type[AbstractContextManager]
+        | type[AbstractAsyncContextManager]
         | bool
         | None
     ) = True,
 ) -> (
-    typing.Type[AbstractContextManager]
-    | typing.Type[AbstractAsyncContextManager]
+    type[AbstractContextManager]
+    | type[AbstractAsyncContextManager]
     | None
 ):
     import _thread
@@ -416,8 +417,8 @@ def _cast_lock(
 
 
 def cached(
-    cache: BaseCacheImpl | dict | typing.Callable[..., BaseCacheImpl] | None = None,
-    key_maker: typing.Callable[..., typing.Hashable] = make_key,
+    cache: BaseCacheImpl | dict | Callable[..., BaseCacheImpl] | None = None,
+    key_maker: Callable[..., Hashable] = make_key,
     clear_reuse: bool = False,
     callback: _Callback | None = None,
     copy_level: int = 1,
@@ -428,7 +429,7 @@ def cached(
         | bool
         | None
     ) = True,
-) -> typing.Callable[[FT], FT]:
+) -> Callable[[FT], FT]:
     """
     Decorator to memoize function/method results.
 


### PR DESCRIPTION
Modernized utils.py typing to use PEP 585 and PEP 604 standards.

Main points:
- Switched typing.Callable/Tuple/Type to native collections.abc and type[...] (PEP 585)
- Replaced optional/union with pipe | syntax (PEP 604)
- Added proper Any types to *args and **kwds

Ready to merge.
