### PR TITLE
workflows: use uv for Linux builds, make Rust targets more explicit, enable riscv64 builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,12 +58,12 @@ jobs:
     strategy:
       matrix:
         platform:
-          - { target: x86_64, interpreter: *interpreters }
-          - { target: x86, interpreter: *interpreters }
-          - { target: aarch64, interpreter: *interpreters }
-          - { target: armv7, interpreter: *interpreters }
-          - { target: s390x, interpreter: *interpreters }
-          - { target: ppc64le, interpreter: *interpreters }
+          - { target: x86_64-unknown-linux-gnu, arch: x86_64, interpreter: *interpreters }
+          - { target: i686-unknown-linux-gnu, arch: x86, interpreter: *interpreters }
+          - { target: aarch64-unknown-linux-gnu, arch: aarch64, interpreter: *interpreters }
+          - { target: armv7-unknown-linux-gnueabihf, arch: armv7, interpreter: *interpreters }
+          - { target: s390x-unknown-linux-gnu, arch: s390x, interpreter: *interpreters }
+          - { target: powerpc64le-unknown-linux-gnu, arch: ppc64le, interpreter: *interpreters }
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -90,7 +90,7 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-linux-${{ matrix.platform.target }}
+          name: wheels-linux-${{ matrix.platform.arch }}
           path: dist
 
   build-musllinux:
@@ -98,10 +98,10 @@ jobs:
     strategy:
       matrix:
         platform:
-          - { target: x86_64, interpreter: *interpreters }
-          - { target: x86, interpreter: *interpreters }
-          - { target: aarch64, interpreter: *interpreters }
-          - { target: armv7, interpreter: *interpreters }
+          - { target: x86_64-unknown-linux-musl, arch: x86_64, interpreter: *interpreters }
+          - { target: i686-unknown-linux-musl, arch: x86, interpreter: *interpreters }
+          - { target: aarch64-unknown-linux-musl, arch: aarch64, interpreter: *interpreters }
+          - { target: armv7-unknown-linux-musleabihf, arch: armv7, interpreter: *interpreters }
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -128,7 +128,7 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-musllinux-${{ matrix.platform.target }}
+          name: wheels-musllinux-${{ matrix.platform.arch }}
           path: dist
 
   build-windows:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,6 +64,7 @@ jobs:
           - { target: armv7-unknown-linux-gnueabihf, arch: armv7, interpreter: *interpreters }
           - { target: s390x-unknown-linux-gnu, arch: s390x, interpreter: *interpreters }
           - { target: powerpc64le-unknown-linux-gnu, arch: ppc64le, interpreter: *interpreters }
+          - { target: riscv64gc-unknown-linux-gnu, arch: riscv64, interpreter: *interpreters }
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -102,6 +103,7 @@ jobs:
           - { target: i686-unknown-linux-musl, arch: x86, interpreter: *interpreters }
           - { target: aarch64-unknown-linux-musl, arch: aarch64, interpreter: *interpreters }
           - { target: armv7-unknown-linux-musleabihf, arch: armv7, interpreter: *interpreters }
+          - { target: riscv64gc-unknown-linux-musl, arch: riscv64, interpreter: *interpreters }
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,9 +70,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: "3.x"
+          activate-environment: true
+          enable-cache: false
+          python-version: "3"
 
       - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         # zizmor: ignore[cache-poisoning]
@@ -106,9 +108,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: "3.x"
+          activate-environment: true
+          enable-cache: false
+          python-version: "3"
 
       - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         # zizmor: ignore[cache-poisoning]


### PR DESCRIPTION
Make use of RISE's Native RISC-V Runners to build cachebox for riscv64. This requires enabling them for the repository as a GitHub Application. More info regarding enabling them is available here: https://riscv-runners.riseproject.dev/

This includes workflow tweaks to:

1. Use the uv tool for the Linux builds, which is generally faster and supports more architectures
2. Make the Rust toolchains more explicit (already done elsewhere in the workflows), since some platforms like riscv64 and ppc64 need this.

I tried a test run on my fork. You can review the results here (note that I added an extra commit just to make the publish job run to test it): https://github.com/threexc/cachebox/pull/1

This is being done on behalf of [RISE](https://riseproject.dev/), using the [RISC-V Wheels](https://stanfromireland.github.io/riscv-wheels/) dashboard to track upstream support for the Python ecosystem.